### PR TITLE
multi root scheme suggestion

### DIFF
--- a/cmd/cli/convert.go
+++ b/cmd/cli/convert.go
@@ -91,6 +91,8 @@ func runConvert(ctx context.Context, co *options.ConvertOptions, args []string) 
 
 	cs := convert.NewService(
 		convert.WithFormat(frmt),
+		convert.WithSelectRoot(co.SelectRoot),
+		convert.WithVirtualRootScheme(co.VirtRootScheme),
 	)
 
 	if err := cs.Convert(ctx, f, out); err != nil {

--- a/cmd/cli/options/convert.go
+++ b/cmd/cli/options/convert.go
@@ -6,9 +6,11 @@ import (
 
 // ConvertOptions defines the options for the `convert` command
 type ConvertOptions struct {
-	Format     string
-	Encoding   string
-	OutputPath string
+	Format         string
+	Encoding       string
+	OutputPath     string
+	SelectRoot     string
+	VirtRootScheme bool
 }
 
 // AddFlags adds command line flags for the ConvertOptions struct
@@ -16,4 +18,7 @@ func (o *ConvertOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.Format, "format", "f", "", "the output format [spdx, spdx-2.3, cyclonedx, cyclonedx-1.4]")
 	cmd.Flags().StringVarP(&o.Encoding, "encoding", "e", "json", "the output encoding [spdx: [text, json] cyclonedx: [json]")
 	cmd.Flags().StringVarP(&o.OutputPath, "output", "o", "", "path to write the converted SBOM")
+	cmd.Flags().StringVarP(&o.SelectRoot, "select-root", "r", "", "select root id")
+	cmd.Flags().BoolVarP(&o.VirtRootScheme, "virtual-root", "", false, "enable virtual root for multi targets")
+
 }

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -39,7 +39,7 @@ func (s *Service) Convert(_ context.Context, in io.ReadSeekCloser, out io.WriteC
 		return err
 	}
 
-	doc = s.HandleMultiTargets(doc)
+	doc = s.HandleMultiRoots(doc)
 
 	w := writer.New()
 	w.Options.Format = s.Format.Format
@@ -47,7 +47,7 @@ func (s *Service) Convert(_ context.Context, in io.ReadSeekCloser, out io.WriteC
 	return w.WriteStream(doc, out)
 }
 
-func (s *Service) HandleMultiTargets(doc *sbom.Document) *sbom.Document {
+func (s *Service) HandleMultiRoots(doc *sbom.Document) *sbom.Document {
 	roots := doc.GetRootNodes()
 
 	if len(roots) > 1 {

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/bom-squad/protobom/pkg/reader"
+	"github.com/bom-squad/protobom/pkg/sbom"
 	"github.com/bom-squad/protobom/pkg/writer"
 
 	"github.com/bom-squad/go-cli/pkg/domain"
@@ -14,7 +15,9 @@ import (
 var _ domain.ConvertService = (*Service)(nil)
 
 type Service struct {
-	Format *format.Format
+	Format         *format.Format
+	SelectRoot     string
+	VirtRootScheme bool
 }
 
 func NewService(opts ...Option) *Service {
@@ -36,8 +39,68 @@ func (s *Service) Convert(_ context.Context, in io.ReadSeekCloser, out io.WriteC
 		return err
 	}
 
+	doc = s.HandleMultiTargets(doc)
+
 	w := writer.New()
 	w.Options.Format = s.Format.Format
 
 	return w.WriteStream(doc, out)
+}
+
+func (s *Service) HandleMultiTargets(doc *sbom.Document) *sbom.Document {
+	roots := doc.GetRootNodes()
+
+	if len(roots) > 1 {
+		if s.SelectRoot != "" {
+			doc = SelectRootScheme(doc, s.SelectRoot)
+		}
+
+		if s.VirtRootScheme {
+			doc = VirtualRootScheme(doc)
+		}
+	}
+
+	return doc
+}
+
+const (
+	VirtualRootDescription = "virtual root scheme, refer roots through dependencies"
+	VirtualRootID          = "virutal-root-scheme-id"
+)
+
+func SelectRootScheme(doc *sbom.Document, selectRoots string) *sbom.Document {
+	for _, root := range doc.GetRootNodes() {
+		if selectRoots == root.Id {
+			nodeList := doc.GetNodeList()
+			nL := nodeList.NodeGraph(root.Id)
+			doc.NodeList = nL
+			doc.NodeList.RootElements = []string{root.Id}
+			return doc
+		}
+	}
+
+	return doc
+}
+
+func VirtualRootScheme(doc *sbom.Document) *sbom.Document {
+
+	doc.NodeList.AddNode(&sbom.Node{
+		Id:          VirtualRootID,
+		Type:        0,
+		Description: VirtualRootDescription,
+	})
+	doc.NodeList.RootElements = []string{VirtualRootID}
+
+	var ids []string
+	for _, root := range doc.GetRootNodes() {
+		ids = append(ids, root.Id)
+	}
+
+	doc.NodeList.AddEdge(&sbom.Edge{
+		Type: 0,
+		From: VirtualRootID,
+		To:   ids,
+	})
+
+	return doc
 }

--- a/pkg/convert/options.go
+++ b/pkg/convert/options.go
@@ -9,3 +9,15 @@ func WithFormat(f *format.Format) Option {
 		s.Format = f
 	}
 }
+
+func WithSelectRoot(selectRoot string) Option {
+	return func(s *Service) {
+		s.SelectRoot = selectRoot
+	}
+}
+
+func WithVirtualRootScheme(virtRootScheme bool) Option {
+	return func(s *Service) {
+		s.VirtRootScheme = virtRootScheme
+	}
+}


### PR DESCRIPTION
Suggestion tries to allow the user some control and how to manage multi root sboms.

It main goal is to allow spdx to cdx conversions where there are many root elemenets.

User can chose between different schemes.
* Select specific root scheme - this will allow user select a specific root and graph to export
* Vritual root scheme -  a new virutal root will be created above the multi targets. 

Note that both schemes change the graph and there for the SBOM.
