### PR TITLE
Feature: Introduce diff Command for Version Comparison

### DIFF
--- a/cmd/cli/convert.go
+++ b/cmd/cli/convert.go
@@ -131,6 +131,26 @@ func parseFormat(f, e string, r io.ReadSeekCloser) (*format.Format, error) {
 	return format, nil
 }
 
+// parseFormat parses the format string and returns target format
+// if format string is empty, it will try to detect the format automatically and return the detected one
+func parseFormatNoInverse(f, e string, r io.ReadSeekCloser) (*format.Format, error) {
+	if f == "" {
+		df, err := format.Detect(r)
+		if err != nil {
+			return nil, err
+		}
+
+		return df, nil
+	}
+
+	format, err := format.Parse(f, e)
+	if err != nil {
+		return nil, err
+	}
+
+	return format, nil
+}
+
 func createOutputStream(out string, frmt *format.Format) (io.WriteCloser, *string, error) {
 	log := zap.S()
 

--- a/cmd/cli/diff.go
+++ b/cmd/cli/diff.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+
+	"github.com/bom-squad/sbom-convert/cmd/cli/options"
+	"github.com/bom-squad/sbom-convert/pkg/diff"
+	"github.com/bom-squad/sbom-convert/pkg/format"
+)
+
+func DiffCommand() *cobra.Command {
+	co := &options.DiffOptions{}
+	c := &cobra.Command{
+		Use:        "diff",
+		Aliases:    []string{"df"},
+		SuggestFor: []string{"diff"},
+		Short:      "Diff between two SBOMS, agnostic to format CycloneDX and SPDX SBOMs",
+		Long:       `Diff between two SBOMS, agonstic to format CycloneDX and SPDX.`,
+		Example: `
+sbom-diff diff sbom_1.cdx.json  sbom_2.cdx.json                           output to stdout in inverse format
+sbom-diff diff sbom_1.spdx.json sbom_2.cdx.json -o sbom.cdx.json          output to a file
+sbom-diff diff sbom_1.cdx.json sbom_2.cdx.json -f spdx-2.3         		  select to a specific format
+sbom-diff diff sbom_1.cdx.json sbom_2.cdx.json -f spdx -e text   	      select specific encoding
+	 				`,
+		SilenceErrors:     true,
+		SilenceUsage:      true,
+		DisableAutoGenTag: true,
+		Args:              cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDiff(cmd.Context(), co, args)
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmd.Parent().PersistentPreRunE(cmd.Parent(), args); err != nil {
+				return err
+			}
+
+			if err := options.BindConfig(viper.GetViper(), cmd); err != nil {
+				return err
+			}
+
+			return validateDiffOptions(co, args)
+		},
+	}
+
+	co.AddFlags(c)
+
+	return c
+}
+
+func validateDiffOptions(_ *options.DiffOptions, _ []string) error {
+	return nil
+}
+
+// runDiff is the main entrypoint for the `diff` command
+func runDiff(ctx context.Context, co *options.DiffOptions, args []string) error {
+	log := zap.S()
+	log.Info("Running Diff command ...")
+	path1 := args[0]
+	path2 := args[1]
+
+	f1, err := os.Open(path1)
+	if err != nil {
+		return err
+	}
+	defer f1.Close()
+
+	f2, err := os.Open(path2)
+	if err != nil {
+		return err
+	}
+	defer f2.Close()
+
+	output_frmt, err := parseFormatNoInverse(co.Format, co.Encoding, f1)
+	if err != nil {
+		return err
+	}
+	log.Debugf("Output format %s", output_frmt)
+
+	df1, err := format.Detect(f1)
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("First '%s' format '%s'", path1, df1)
+
+	df2, err := format.Detect(f1)
+	if err != nil {
+		return err
+	}
+	log.Debugf("Second '%s' format '%s'", path2, df2)
+
+	overwrited := true
+	out1, outPath1, err := createOutputStream(fmt.Sprintf("%s.added", co.OutputPath), output_frmt)
+	if err != nil {
+		return err
+	}
+	out2, outPath2, err := createOutputStream(fmt.Sprintf("%s.removed", co.OutputPath), output_frmt)
+	if err != nil {
+		return err
+	}
+
+	dfs := diff.NewService(
+		diff.WithFormat(output_frmt),
+	)
+
+	if err := dfs.Diff(ctx, f1, f2, out1, out2); err != nil {
+		out1.Close()
+		out2.Close()
+
+		if !overwrited {
+			return err
+		}
+
+		log.Debugf("removing output file %s", *outPath1)
+		if rerr := os.Remove(*outPath1); rerr != nil {
+			log.Info("failed to remove output file", zap.String("path", *outPath1), zap.Error(rerr))
+		}
+		log.Debugf("removing output file %s", *outPath2)
+		if rerr := os.Remove(*outPath2); rerr != nil {
+			log.Info("failed to remove output file", zap.String("path", *outPath2), zap.Error(rerr))
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/cmd/cli/options/diff.go
+++ b/cmd/cli/options/diff.go
@@ -1,0 +1,19 @@
+package options
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// ConvertOptions defines the options for the `convert` command
+type DiffOptions struct {
+	Format     string
+	Encoding   string
+	OutputPath string
+}
+
+// AddFlags adds command line flags for the ConvertOptions struct
+func (o *DiffOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Format, "format", "f", "", "the output format [spdx, spdx-2.3, cyclonedx, cyclonedx-1.0, cyclonedx-1.1, cyclonedx-1.2, cyclonedx-1.3, cyclonedx-1.4, cyclonedx-1.5]") //nolint: lll
+	cmd.Flags().StringVarP(&o.Encoding, "encoding", "e", "json", "the output encoding [spdx: [text, json] cyclonedx: [json]")
+	cmd.Flags().StringVarP(&o.OutputPath, "output", "o", "", "path to write the diff SBOM")
+}

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -74,6 +74,10 @@ func NewRootCmd() *cobra.Command {
 	cvtCmd := ConvertCommand()
 	rootCmd.AddCommand(cvtCmd)
 
+	// Commands
+	diffCmd := DiffCommand()
+	rootCmd.AddCommand(diffCmd)
+
 	// Manpages
 	rootCmd.AddCommand(ManCommand(rootCmd))
 	return rootCmd

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/muesli/mango-cobra v1.2.0
 	github.com/muesli/roff v0.1.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
@@ -23,6 +24,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/muesli/mango v0.1.0 // indirect
 	github.com/muesli/mango-pflag v0.1.0 // indirect
@@ -44,3 +46,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/release-utils v0.7.7 // indirect
 )
+
+replace github.com/bom-squad/protobom v0.3.0 => github.com/scribe-security/protobom v0.0.0-20240225125754-709fd9fb85bb
+
+// replace github.com/bom-squad/protobom => ../protobom

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/CycloneDX/cyclonedx-go v0.8.0/go.mod h1:K2bA+324+Og0X84fA8HhN2X066K7B
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/anchore/go-struct-converter v0.0.0-20230627203149-c72ef8859ca9 h1:6COpXWpHbhWM1wgcQN95TdsmrLTba8KQfPgImBXzkjA=
 github.com/anchore/go-struct-converter v0.0.0-20230627203149-c72ef8859ca9/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
-github.com/bom-squad/protobom v0.3.0 h1:1kdKbTmnhigxCQK3f0BJZWeevE+Z0bSGy0o76CFm0Ak=
-github.com/bom-squad/protobom v0.3.0/go.mod h1:IhdpGUnU5LTI5E7blHlGY9SDwJewK0xZd/YdW+ESKY0=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
@@ -33,6 +31,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/muesli/mango v0.1.0 h1:DZQK45d2gGbql1arsYA4vfg4d7I9Hfx5rX/GCmzsAvI=
@@ -43,6 +43,8 @@ github.com/muesli/mango-pflag v0.1.0 h1:UADqbYgpUyRoBja3g6LUL+3LErjpsOwaC9ywvBWe
 github.com/muesli/mango-pflag v0.1.0/go.mod h1:YEQomTxaCUp8PrbhFh10UfbhbQrM/xJ4i2PB8VTLLW0=
 github.com/muesli/roff v0.1.0 h1:YD0lalCotmYuF5HhZliKWlIx7IEhiXeSfq7hNjFqGF8=
 github.com/muesli/roff v0.1.0/go.mod h1:pjAHQM9hdUUwm/krAfrLGgJkXJ+YuhtsfZ42kieB2Ig=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -55,6 +57,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/scribe-security/protobom v0.0.0-20240225125754-709fd9fb85bb h1:L4+zRL/AuN+kK/ZKW/sJSCE4aKrO4qAWagd/sVMcYA8=
+github.com/scribe-security/protobom v0.0.0-20240225125754-709fd9fb85bb/go.mod h1:zv9Q1atQgfwhsaW4crHLQdsKTYJ6mlWwe9k4VMdP9+g=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
This PR introduces a new diff command to demonstrate the functionality of the NodeList API.

Note: PR uses the protobom Suggested Diff API - https://github.com/bom-squad/protobom/pull/173

For example, executing 
`go run main.go diff syft.alpine.3.18.6.cdx.json syft.alpine.3.19.1.cdx.json`
 will generate a comparison between two versions of a Syft Alpine image. The output will present the version drift of packages, showing which packages have been added, removed, or changed between the two versions.

Here's a sample output:
```
+--------------+---------+-------------+-------------+
| PACKAGE NAME | ACTION  | OLD VERSION | NEW VERSION |
+--------------+---------+-------------+-------------+
| alpine       | changed | 3.18.6      | 3.19.1      |
+--------------+---------+-------------+-------------+
ROOT ELEMENTS

+------------------------+---------+-------------+----------------------+
|      PACKAGE NAME      | ACTION  | OLD VERSION |     NEW VERSION      |
+------------------------+---------+-------------+----------------------+
| alpine                 | changed | 3.18.6      | 3.19.1               |
| alpine                 | changed | 3.18.6      | 3.19.1               |
| alpine-baselayout      | changed | 3.4.3-r1    | 3.4.3-r2             |
| alpine-baselayout-data | changed | 3.4.3-r1    | 3.4.3-r2             |
| apk-tools              | changed | 2.14.0-r2   | 2.14.0-r5            |
| busybox                | changed | 1.36.1-r5   | 1.36.1-r15           |
| busybox-binsh          | changed | 1.36.1-r5   | 1.36.1-r15           |
| musl                   | changed | 1.2.4-r2    | 1.2.4_git20230717-r4 |
| musl-utils             | changed | 1.2.4-r2    | 1.2.4_git20230717-r4 |
| scanelf                | changed | 1.3.7-r1    | 1.3.7-r2             |
| ssl_client             | changed | 1.36.1-r5   | 1.36.1-r15           |
| zlib                   | changed | 1.2.13-r1   | 1.3.1-r0             |
+------------------------+---------+-------------+----------------------+

```